### PR TITLE
Use regex to parse modmails for mentions

### DIFF
--- a/modmail/bot/extensions/mail.py
+++ b/modmail/bot/extensions/mail.py
@@ -36,11 +36,11 @@ class Mail(commands.Cog):
         ]
 
         mentions = []
-        for uid in re.findall(r"<@!?(\d{18})>", message.content):
+        for uid in re.findall(r"<@!?(\d+)>", message.content):
             if user := self.bot.get_user(int(uid)):
                 mentions.append(f"@{user.name}: {user.id}")
 
-        for cid in re.findall(r"<#(\d{18})>", message.content):
+        for cid in re.findall(r"<#(\d+)>", message.content):
             if chan := self.bot.get_channel(int(cid)):
                 mentions.append(f"#{chan.name}: {chan.id}")
 

--- a/modmail/bot/extensions/mail.py
+++ b/modmail/bot/extensions/mail.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import random
+import re
 import typing as t
 
 import discord
@@ -34,11 +35,20 @@ class Mail(commands.Cog):
             {"name": "Message", "value": message.content, "inline": False},
         ]
 
-        if message.mentions:
+        mentions = []
+        for uid in re.findall(r"<@!?(\d{18})>", message.content):
+            if user := self.bot.get_user(int(uid)):
+                mentions.append(f"@{user.name}: {user.id}")
+
+        for cid in re.findall(r"<#(\d{18})>", message.content):
+            if chan := self.bot.get_channel(int(cid)):
+                mentions.append(f"#{chan.name}: {chan.id}")
+
+        if mentions:
             fields.append(
                 {
                     "name": "Other Mentions",
-                    "value": "\n".join((f"{m.name}: {m.id}") for m in message.mentions),
+                    "value": "\n".join(mentions),
                     "inline": False,
                 }
             )


### PR DESCRIPTION
`discord.message.mentions` was observed to be missing mentions manually entered as <@####>. This pull request eliminates the use of `message.mentions` in favor of parsing the message content using regex. I have accounted for user and channel mentions, but not role mentions as they feel insignificant in a modmail. Let me know if you'd like any changes.

Closes #7 